### PR TITLE
Address empty settings file bug

### DIFF
--- a/Assets/BossModuleManager.cs
+++ b/Assets/BossModuleManager.cs
@@ -35,6 +35,8 @@ public class BossModuleManager : MonoBehaviour, IDictionary<string, object>
             try
             {
                 Settings = JsonConvert.DeserializeObject<BossModuleSettings>(File.ReadAllText(_settingsFile), new StringEnumConverter());
+                if (Settings == null)
+                    throw new Exception("Settings could not be read. Creating new Settings...");
                 Debug.LogFormat(@"[BossModuleManager] Settings successfully loaded");
             }
             catch (Exception e)


### PR DESCRIPTION
- There is a strange bug with the JSON parser used with JsonConvert.SerializeObject that sometimes results in the data in the JSON file to be completely empty. The cause of this bug is unknown, but has been present in many implementations of KMModSettings, such as in ModSettings in Tweaks (which is also used in many of my own mods), KMColorblindMode, and now the Boss Module Manager.
This patch will check to see if Settings is empty and if it is, will automatically throw a custom exception so that a new BossModuleSettings instance can be made and written to the file.