### PR TITLE
Optional additions to the Boss Manager

### DIFF
--- a/Assets/BossModuleManager.cs
+++ b/Assets/BossModuleManager.cs
@@ -111,12 +111,12 @@ public class BossModuleManager : MonoBehaviour, IDictionary<string, object>
     private string[] GetIgnoredModules(string moduleName)
     {
         string[] ret;
-        if (Settings.IgnoredModules.TryGetValue(moduleName, out ret))
+        string moduleName2 = moduleName.Contains("'") ? moduleName.Replace("'", "’") : moduleName.Replace("’", "'");
+        if (Settings.IgnoredModules.TryGetValue(moduleName, out ret) || Settings.IgnoredModules.TryGetValue(moduleName2, out ret))
         {
             Debug.LogFormat(@"[BossModuleManager] Request for {0}’s ignore list successful.", moduleName);
             return ret.ToArray();   // Take a copy of the list so that the caller doesn’t modify ours
         }
-
         Debug.LogFormat(@"[BossModuleManager] Request for {0}’s ignore list failed.", moduleName);
         return null;
     }


### PR DESCRIPTION
Contains the commit featured in #2 

- Some debugging was added for testing the Boss Manager in Unity
- ModuleIDs were added to the dictionary, so that a future version of KMBossModule could use the ModuleType to get ignore lists, in case the display name isn't satisfactory.

These additions are not important, especially since they would both likely need an update to KMBossModule, which is not guaranteed for each module that uses it. However, I thought I'd leave them here anyway just in case they could be useful.